### PR TITLE
Fix buggy ES6 polyfills

### DIFF
--- a/src/js/polyfills/codepointat.js
+++ b/src/js/polyfills/codepointat.js
@@ -1,21 +1,32 @@
 define(function() {
+  /*! http://mths.be/codepointat v0.1.0 by @mathias */
   if (!String.prototype.codePointAt) {
-    /**
-     * ES6 Unicode Shims 0.1
-     * (c) 2012 Steven Levithan <http://slevithan.com/>
-     * MIT license
-     */
-    String.prototype.codePointAt = function (pos) {
-      pos = isNaN(pos) ? 0 : pos;
-      var str = String(this),
-          code = str.charCodeAt(pos),
-          next;
-      // If a surrogate pair
-      if (0xD800 <= code && code <= 0xDBFF && 0xDC00 <= next && next <= 0xDFFF) {
-        next = str.charCodeAt(pos + 1);
-        return ((code - 0xD800) * 0x400) + (next - 0xDC00) + 0x10000;
+    String.prototype.codePointAt = function(position) {
+      var string = String(this);
+      var size = string.length;
+      // `ToInteger`
+      var index = position ? Number(position) : 0;
+      if (isNaN(index)) {
+        index = 0;
       }
-      return code;
+      // Account for out-of-bounds indices:
+      if (index < 0 || index >= size) {
+        return undefined;
+      }
+      // Get the first code unit
+      var first = string.charCodeAt(index);
+      var second;
+      if ( // check if it’s the start of a surrogate pair
+        first >= 0xD800 && first <= 0xDBFF && // high surrogate
+        size > index + 1 // there is a next code unit
+      ) {
+        second = string.charCodeAt(index + 1);
+        if (second >= 0xDC00 && second <= 0xDFFF) { // low surrogate
+          // http://mathiasbynens.be/notes/javascript-encoding#surrogate-formulae
+          return (first - 0xD800) * 0x400 + second - 0xDC00 + 0x10000;
+        }
+      }
+      return first;
     };
   }
 

--- a/src/js/polyfills/fromcodepoint.js
+++ b/src/js/polyfills/fromcodepoint.js
@@ -1,20 +1,38 @@
 define(function() {
+  /*! http://mths.be/fromcodepoint v0.1.0 by @mathias */
   if (!String.fromCodePoint) {
-      /*!
-       * ES6 Unicode Shims 0.1
-       * (c) 2012 Steven Levithan <http://slevithan.com/>
-       * MIT License
-       */
-      String.fromCodePoint = function fromCodePoint () {
-          var chars = [], point, offset, units, i;
-          for (i = 0; i < arguments.length; ++i) {
-              point = arguments[i];
-              offset = point - 0x10000;
-              units = point > 0xFFFF ? [0xD800 + (offset >> 10), 0xDC00 + (offset & 0x3FF)] : [point];
-              chars.push(String.fromCharCode.apply(null, units));
-          }
-          return chars.join("");
-      };
+    String.fromCodePoint = function() {
+      var codeUnits = [];
+      var floor = Math.floor;
+      var highSurrogate;
+      var lowSurrogate;
+      var index = -1;
+      var length = arguments.length;
+      if (!length) {
+        return '';
+      }
+      while (++index < length) {
+        var codePoint = Number(arguments[index]);
+        if (
+          !isFinite(codePoint) || // `NaN`, `+Infinity`, or `-Infinity`
+          codePoint < 0 || // not a valid Unicode code point
+          codePoint > 0x10FFFF || // not a valid Unicode code point
+          floor(codePoint) != codePoint // not an integer
+        ) {
+          throw RangeError('Invalid code point: ' + codePoint);
+        }
+        if (codePoint <= 0xFFFF) { // BMP code point
+          codeUnits.push(codePoint);
+        } else { // Astral code point; split in surrogate halves
+          // http://mathiasbynens.be/notes/javascript-encoding#surrogate-formulae
+          codePoint -= 0x10000;
+          highSurrogate = (codePoint >> 10) + 0xD800;
+          lowSurrogate = (codePoint % 0x400) + 0xDC00;
+          codeUnits.push(highSurrogate, lowSurrogate);
+        }
+      }
+      return String.fromCharCode.apply(null, codeUnits);
+    };
   }
 
   return String.fromCodePoint;


### PR DESCRIPTION
Replace the old ES6 polyfills with properly tested alternatives.

`String.fromCodePoint`: http://mths.be/fromcodepoint
`String.prototype.codePointAt`: http://mths.be/codepointat
