### PR TITLE
Fix Python SMP codepoint representations.

### DIFF
--- a/src/js/components/representations.js
+++ b/src/js/components/representations.js
@@ -38,14 +38,15 @@ define(['jquery',
 
       addRepr(_('Python'), function(n) {
         var str = n.toString(16).toUpperCase(),
-            pad = 4;
+            pad = 4, chr = 'u';
         if (n > 0xFFFF) {
-          pad = 6;
+          pad = 8;
+          chr = 'U';
         }
         while (str.length < pad) {
           str = "0" + str;
         }
-        return '\\u'+str;
+        return '\\'+chr+str;
       });
 
       addRepr(_('Ruby'), function(n) {


### PR DESCRIPTION
Non-BMP codepoints in Python use the same notation as in C: `\Uhhhhhhhh`. See the [Python string literals documentation](http://docs.python.org/2/reference/lexical_analysis.html#index-15).
