### PR TITLE
fix Python representation for codepoints > 0xffff

### DIFF
--- a/src/js/components/representations.js
+++ b/src/js/components/representations.js
@@ -38,14 +38,16 @@ define(['jquery',
 
       addRepr(_('Python'), function(n) {
         var str = n.toString(16).toUpperCase(),
-            pad = 4;
+            pad = 4,
+            prefix = '\\u';
         if (n > 0xFFFF) {
-          pad = 6;
+          pad = 8;
+          prefix = '\\U';
         }
         while (str.length < pad) {
           str = "0" + str;
         }
-        return '\\u'+str;
+        return prefix+str;
       });
 
       addRepr(_('Ruby'), function(n) {


### PR DESCRIPTION
`U+1F493` is shown as `\u01F493` which is incorrect. It should be `\U0001F493`. In general, the syntax is `\uXXXX` and `\UXXXXXXXX`. See http://docs.python.org/3/reference/lexical_analysis.html#string-and-bytes-literals
