### PR TITLE
use \uXXXX for Javascript, JSON and Java.

### DIFF
--- a/src/js/components/representations.js
+++ b/src/js/components/representations.js
@@ -59,7 +59,7 @@ define(['jquery',
 
       addRepr(_('JavaScript, JSON and Java'), function(n) {
         return $.map(tools.codepoint_to_utf16(n), function(x) {
-          return '\\u'+x.toString(16).toUpperCase();
+          return '\\u' + tools.format_codepoint(x);
         }).join('');
       });
 


### PR DESCRIPTION
`U+0041` is mistakenly represented as `\u41`. It should be `\u0041`, see [json rfc](https://tools.ietf.org/html/rfc7159#section-7).
