### PR TITLE
rfc 5137 requires 4...6 hexdigits

### DIFF
--- a/src/js/components/representations.js
+++ b/src/js/components/representations.js
@@ -33,7 +33,11 @@ define(['jquery',
                 }).insertAfter(repr);
 
       addRepr(_('RFC 5137'), function(n) {
-        return '\\u\''+n.toString(16).toUpperCase()+'\'';
+        var str = n.toString(16).toUpperCase();
+        while (str.length < 4) { // at least 4 hexdigits
+          str = "0" + str;
+        }
+        return '\\u\'' + str + '\'';
       });
 
       addRepr(_('Python'), function(n) {


### PR DESCRIPTION
`U+0041` is mistakenly represented as `\u'41'`. It should be `\u'0041'` instead, see [rfc 5137](http://tools.ietf.org/html/rfc5137#section-5.1):

```
EmbeddedUnicodeChar =  %x5C.75.27 4*6HEXDIG %x27
      ; starting with lowercase "\u" and "'" and ending with "'".
```
