### PR TITLE
Windows-1252 should not be ISO-8859-1

### DIFF
--- a/codepoints.net/views/codepoint/representations.php
+++ b/codepoints.net/views/codepoint/representations.php
@@ -33,7 +33,7 @@
     </tr>
     <?php
     ini_set('mbstring.substitute_character', "none");
-    $moji = mb_convert_encoding($codepoint->getSafeChar(), 'UTF-8', 'ISO-8859-1');
+    $moji = mb_convert_encoding($codepoint->getSafeChar(), 'UTF-8', 'Windows-1252');
     if ($moji): ?>
       <tr>
         <th title="<?php _e('approx. ISO-8859-1, Latin 1, “us-ascii”, ...')?>"><?php _e('Wrong windows-1252 Mojibake')?></th>


### PR DESCRIPTION
The site is displaying the wrong Windows-1252 mojibake for [U+2BC6](https://codepoints.net/U+2BC6) for instance, â¯ (where the last code point is U+0086) instead of â¯†. Windows-1252 has the dagger character (U+2020) for byte 0x86; the original ISO-8859-1 has nothing according to [Wikipedia](https://en.wikipedia.org/wiki/ISO/IEC_8859-1#Code_page_layout), and judging from the site, instead of throwing an error, `mb_convert_encoding` decodes byte 0x86 as U+0086 in ISO-8859-1. I haven't tested the output of this code, but I expect it will output â¯† for U+2BC6 as desired.